### PR TITLE
style: modify h1 text

### DIFF
--- a/src/components/MainVisual.tsx
+++ b/src/components/MainVisual.tsx
@@ -16,14 +16,23 @@ export default function MainVisual(props: Props) {
     >
       <Box>
         <Center>
-          <Heading as="h1" size={['lg', 'xl', '2xl', '3xl']} color="white">
+          <Text
+            as='b'
+            sx={{ fontFamily: "Georgia, serif" }}
+            fontSize={['2xl', '3xl', '5xl', '6xl']}
+            color="white">
             NPO 法人 MOTTAI
-          </Heading>
+          </Text>
         </Center>
         <Center>
-          <Text as="b" fontSize={['md', 'xl', '2xl', '3xl']} color="white">
+          <Heading
+            as="h1"
+            sx={{ fontFamily: "system-ui, sans-serif" }}
+            fontSize={['md', 'xl', '2xl', '3xl']}
+            color="white"
+          >
             {props.title}
-          </Text>
+          </Heading>
         </Center>
       </Box>
     </Box>


### PR DESCRIPTION
[対応内容]
ページ内容のh1タグの修正

[依頼内容]

```
一点、公式サイトの内部SEO的な話でご相談があります！
現在、公式サイトがSEO的な観点から、若干修正した方がいいかもという点がいくつかあります。
具体的には下記の通りです
・全ページの<title>タグと「NPO法人MOTTAI」になっている
・全ページの<h1>タグが「NPO法人MOTTAI」になっている
上記の課題に対して下記の点の対応をすることは可能でしょうか？
<title>タグおよび<h1>を各ページに合わせて内容にしてユニークなものにしたい
```